### PR TITLE
style(composer, thread): bolder send button + editorial suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/google": "^3.0.0",
     "jose": "^6.0.0",
+    "lucide-react": "^1.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -123,6 +124,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.3.0",
     "jose": "^6.2.2",
+    "lucide-react": "^1.9.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "ts-jest": "^29.4.9",

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -36,9 +36,10 @@ export function Composer({ className, placeholder = 'Ask something...' }: Compos
       <button
         type="submit"
         disabled={isLoading || !input.trim()}
-        className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-[var(--bui-fg-secondary,#a1a1aa)] hover:text-[var(--bui-fg,#f4f4f5)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label="Send"
+        className="absolute right-2 top-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-full bg-[var(--bui-primary,#18181b)] text-[var(--bui-user-fg,#f4f4f5)] transition-all enabled:hover:bg-[var(--bui-primary-hover,#27272a)] enabled:active:scale-95 disabled:bg-[var(--bui-bg-elevated,#27272a)] disabled:text-[var(--bui-fg-faint,#52525b)] disabled:cursor-not-allowed"
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M14.5 1.5L7 9M14.5 1.5L10 14.5L7 9M14.5 1.5L1.5 6L7 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
         </svg>
       </button>

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { Send } from 'lucide-react';
 import { useChatContext } from './ChatProvider';
 
 export interface ComposerProps {
@@ -39,9 +40,7 @@ export function Composer({ className, placeholder = 'Ask something...' }: Compos
         aria-label="Send"
         className="absolute right-2 top-1/2 -translate-y-1/2 flex h-8 w-8 items-center justify-center rounded-full bg-[var(--bui-primary,#18181b)] text-[var(--bui-user-fg,#f4f4f5)] transition-all enabled:hover:bg-[var(--bui-primary-hover,#27272a)] enabled:active:scale-95 disabled:bg-[var(--bui-bg-elevated,#27272a)] disabled:text-[var(--bui-fg-faint,#52525b)] disabled:cursor-not-allowed"
       >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M14.5 1.5L7 9M14.5 1.5L10 14.5L7 9M14.5 1.5L1.5 6L7 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-        </svg>
+        <Send size={14} strokeWidth={1.75} />
       </button>
     </form>
   );

--- a/src/components/Thread.tsx
+++ b/src/components/Thread.tsx
@@ -29,25 +29,34 @@ export function Thread({ className, emptyMessage, suggestions }: ThreadProps) {
     <div ref={scrollRef} className={`${className || ''}`}>
       <div className="p-6 space-y-6">
         {messages.length === 0 && (
-          <div className="text-center py-16">
-            <div className="text-[var(--bui-fg-faint,#52525b)] text-sm">
-              <p className="text-[var(--bui-fg-secondary,#a1a1aa)] mb-4">
-                {emptyMessage || 'Send a message to get started'}
-              </p>
-              {suggestions && suggestions.length > 0 && (
-                <div className="flex flex-wrap justify-center gap-2 mt-4">
-                  {suggestions.map((suggestion) => (
-                    <button
-                      key={suggestion}
-                      onClick={() => sendMessage(suggestion)}
-                      className="px-3 py-1.5 text-xs text-[var(--bui-fg-secondary,#a1a1aa)] bg-[var(--bui-bg-elevated,#27272a)] border border-[var(--bui-border-strong,#3f3f46)] rounded-full hover:bg-[var(--bui-bg-hover,#3f3f46)] hover:text-[var(--bui-fg,#f4f4f5)] transition-colors"
+          <div className="py-12">
+            <p className="text-center text-sm text-[var(--bui-fg-secondary,#a1a1aa)]">
+              {emptyMessage || 'Send a message to get started'}
+            </p>
+            {suggestions && suggestions.length > 0 && (
+              <div className="mt-8 flex flex-col divide-y divide-[var(--bui-border,#27272a)] border-y border-[var(--bui-border,#27272a)]">
+                {suggestions.map((suggestion) => (
+                  <button
+                    key={suggestion}
+                    onClick={() => sendMessage(suggestion)}
+                    className="group flex items-center justify-between gap-4 px-5 py-4 text-left text-sm text-[var(--bui-fg,#f4f4f5)] transition-colors hover:bg-[var(--bui-bg-hover,#27272a)]"
+                  >
+                    <span className="flex-1">{suggestion}</span>
+                    <svg
+                      className="shrink-0 text-[var(--bui-fg-faint,#52525b)] transition-all group-hover:translate-x-0.5 group-hover:text-[var(--bui-fg-secondary,#a1a1aa)]"
+                      width="14"
+                      height="14"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      aria-hidden="true"
                     >
-                      {suggestion}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+                      <path d="M4 8h8m0 0L8 4m4 4l-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/Thread.tsx
+++ b/src/components/Thread.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useRef, useEffect } from 'react';
+import { ArrowRight } from 'lucide-react';
 import { useChatContext } from './ChatProvider';
 import { Message } from './Message';
 
@@ -42,17 +43,12 @@ export function Thread({ className, emptyMessage, suggestions }: ThreadProps) {
                     className="group flex items-center justify-between gap-4 px-5 py-4 text-left text-sm text-[var(--bui-fg,#f4f4f5)] transition-colors hover:bg-[var(--bui-bg-hover,#27272a)]"
                   >
                     <span className="flex-1">{suggestion}</span>
-                    <svg
-                      className="shrink-0 text-[var(--bui-fg-faint,#52525b)] transition-all group-hover:translate-x-0.5 group-hover:text-[var(--bui-fg-secondary,#a1a1aa)]"
-                      width="14"
-                      height="14"
-                      viewBox="0 0 16 16"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <ArrowRight
+                      size={14}
+                      strokeWidth={1.75}
                       aria-hidden="true"
-                    >
-                      <path d="M4 8h8m0 0L8 4m4 4l-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                    </svg>
+                      className="shrink-0 text-[var(--bui-fg-faint,#52525b)] transition-all group-hover:translate-x-0.5 group-hover:text-[var(--bui-fg-secondary,#a1a1aa)]"
+                    />
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
Visual tightening of two well-used bits of \`Chat\` surface after a user flagged them as \"doesn't look good\":

### Send button (\`Composer.tsx\`)
Was a plain gray arrow that dropped to 30% opacity when disabled — looked unfinished at rest.
Now a filled circle using \`--bui-primary\` with the \`--bui-user-fg\` icon color. Reads as a proper \"send\" affordance without depending on the surrounding theme.

### Suggestions list (\`Thread.tsx\`)
Was a centered flex-wrap of small gray pills.
Now a full-width stacked list, divided by \`--bui-border\`, each row ends in a chevron that translates on hover. Reads editorial — suits the Rick Rubin palette used in content-intelligence-ui, and scales with longer prompts without wrapping weirdly.

## What's unchanged
- Props / callbacks (\`sendMessage\`, \`suggestions\`, \`emptyMessage\`, \`placeholder\`)
- CSS variable names — downstream themes don't need to update

## Test plan
- [ ] Send button: enabled state reads as a solid primary-colored circle
- [ ] Send button: disabled state is visibly inert but not just "30% opacity"
- [ ] Suggestions: each prompt is a full-width row with chevron on the right
- [ ] Suggestions: hover tints bg and nudges chevron right
- [ ] Still looks correct in both dark-default palette and cream/Rick-Rubin palette used by \`content-intelligence-ui\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)