### PR TITLE
refactor: replace remaining inline SVGs with lucide-react

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
 
 export interface CodeBlockViewProps {
   /** The code content */
@@ -114,17 +115,12 @@ export function CodeBlockView({
         >
           {copied ? (
             <>
-              <svg className="w-3.5 h-3.5 text-[var(--bui-success-fg,#6ee7b7)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-              </svg>
+              <Check size={14} className="text-[var(--bui-success-fg,#6ee7b7)]" />
               Copied
             </>
           ) : (
             <>
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-              </svg>
+              <Copy size={14} />
               Copy
             </>
           )}

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useCallback } from 'react';
+import { Upload, FileText } from 'lucide-react';
 
 export interface UploadedFile {
   name: string;
@@ -133,9 +134,7 @@ export function FileUploadView({
           className="hidden"
         />
 
-        <svg className="w-8 h-8 text-[var(--bui-fg-faint,#52525b)] mx-auto mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
-        </svg>
+        <Upload size={32} strokeWidth={1.5} className="text-[var(--bui-fg-faint,#52525b)] mx-auto mb-2" />
 
         <p className="text-[var(--bui-fg-secondary,#a1a1aa)] text-sm">
           {isDragging ? 'Drop files here' : 'Click or drag files to upload'}
@@ -176,9 +175,7 @@ function FileIcon({ type }: { type: string }) {
       isPdf ? 'bg-[var(--bui-error-muted,rgba(220,38,38,0.08))] text-[var(--bui-error-fg,#f87171)]' :
       'bg-[var(--bui-bg-hover,#3f3f46)] text-[var(--bui-fg-secondary,#a1a1aa)]'
     }`}>
-      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
-      </svg>
+      <FileText size={16} strokeWidth={1.5} />
     </div>
   );
 }

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useSyncExternalStore, useCallback } from 'react';
+import { Sparkles } from 'lucide-react';
 import type { Tool } from '../tool';
 import type { ToolStateStore, ToolStateEntry } from './useToolStateStore';
 import { useChatContext } from './ChatProvider';
@@ -93,9 +94,7 @@ export function Panel({ toolStateStore, tools, getOnAction, className, tool: fil
           />
           <div className="relative flex flex-col items-center gap-3 text-center">
             <div className="w-10 h-10 rounded-xl bg-[var(--bui-bg-elevated,#27272a)] border border-[var(--bui-border-strong,#3f3f46)]/50 flex items-center justify-center">
-              <svg className="w-5 h-5 text-[var(--bui-fg-faint,#52525b)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9.53 16.122a3 3 0 0 0-5.78 1.128 2.25 2.25 0 0 1-2.4 2.245 4.5 4.5 0 0 0 8.4-2.245c0-.399-.078-.78-.22-1.128Zm0 0a15.998 15.998 0 0 0 3.388-1.62m-5.043-.025a15.994 15.994 0 0 1 1.622-3.395m3.42 3.42a15.995 15.995 0 0 0 4.764-4.648l3.876-5.814a1.151 1.151 0 0 0-1.597-1.597L14.146 6.32a15.996 15.996 0 0 0-4.649 4.763m3.42 3.42a6.776 6.776 0 0 0-3.42-3.42" />
-              </svg>
+              <Sparkles size={20} strokeWidth={1.5} className="text-[var(--bui-fg-faint,#52525b)]" />
             </div>
             <div>
               <p className="text-[var(--bui-fg-muted,#71717a)] text-sm font-medium">Canvas</p>

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { Check, X } from 'lucide-react';
 
 export interface ProgressStep {
   label: string;
@@ -91,14 +92,10 @@ export function ProgressView({
                 </div>
               )}
               {step.status === 'done' && (
-                <svg className="w-4 h-4 text-[var(--bui-success-fg,#6ee7b7)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
+                <Check size={16} strokeWidth={3} className="text-[var(--bui-success-fg,#6ee7b7)]" />
               )}
               {step.status === 'error' && (
-                <svg className="w-4 h-4 text-[var(--bui-error-fg,#f87171)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
+                <X size={16} strokeWidth={3} className="text-[var(--bui-error-fg,#f87171)]" />
               )}
             </div>
             <div className="min-w-0 flex-1">

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { Check } from 'lucide-react';
 
 export interface QuestionOption {
   label: string;
@@ -115,9 +116,7 @@ export function QuestionView({
                   : 'border-[var(--bui-border-strong,#3f3f46)]'
               } flex items-center justify-center`}>
                 {isSelected(opt.value) && (
-                  <svg className="w-2.5 h-2.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
+                  <Check size={10} strokeWidth={3} className="text-white" />
                 )}
               </div>
               <div className="min-w-0 flex-1">

--- a/src/components/ToolResult.tsx
+++ b/src/components/ToolResult.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { Component, useEffect, useRef, useSyncExternalStore, useCallback, type ReactNode, type ErrorInfo } from 'react';
+import { AlertCircle } from 'lucide-react';
 import type { Tool } from '../tool';
 import { useToolState, type ToolStateStore } from './useToolStateStore';
 
@@ -24,9 +25,7 @@ class ToolViewErrorBoundary extends Component<
       return (
         <div className="bg-[var(--bui-error-muted,rgba(220,38,38,0.08))] border border-[var(--bui-error-border,rgba(153,27,27,0.5))] rounded-xl p-4">
           <div className="flex items-center gap-2">
-            <svg className="w-4 h-4 text-[var(--bui-error-fg,#f87171)] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
-            </svg>
+            <AlertCircle size={16} className="text-[var(--bui-error-fg,#f87171)] shrink-0" />
             <span className="text-[var(--bui-error-fg,#f87171)] text-sm font-medium">
               {this.props.toolName} view error
             </span>
@@ -289,9 +288,7 @@ export function ToolResult({
     return (
       <div className={`bg-[var(--bui-error-muted,rgba(220,38,38,0.08))] border border-[var(--bui-error-border,rgba(153,27,27,0.5))] rounded-xl p-4 ${className || ''}`}>
         <div className="flex items-center gap-2 mb-2">
-          <svg className="w-4 h-4 text-[var(--bui-error-fg,#f87171)] shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
-          </svg>
+          <AlertCircle size={16} className="text-[var(--bui-error-fg,#f87171)] shrink-0" />
           <span className="text-[var(--bui-error-fg,#f87171)] text-sm font-medium">{toolName} failed</span>
         </div>
         <p className="text-[var(--bui-error-fg,#f87171)]/70 text-xs mb-3">{storeState.error}</p>


### PR DESCRIPTION
## Summary
Swaps the last 10 inline SVG blocks across 6 components for lucide-react icons. Completes the icon sweep started in #4.

| File | Was | Now |
|---|---|---|
| ToolResult | exclamation-circle path (x2) | \`<AlertCircle />\` |
| FileUpload | arrow-up-tray + document-duplicate | \`<Upload />\`, \`<FileText />\` |
| CodeBlock | check path + clipboard path | \`<Check />\`, \`<Copy />\` |
| Progress | check path + x path | \`<Check />\`, \`<X />\` |
| Question | check path | \`<Check />\` |
| Panel | sparkles path | \`<Sparkles />\` |

## Bundle / install impact
None for consumers — \`lucide-react\` is a peerDependency (landed in #4) and icons are tree-shaken. Lilium already pins \`lucide-react@^1.7.0\` so nothing new to install.

## Visual impact
Sizes + strokeWidth + className preserved. Icons render at the same pixel dimensions as before.

## Test plan
- [ ] \`ToolResult\` error state shows an alert-circle icon
- [ ] \`FileUpload\` dropzone shows an upload-tray icon
- [ ] \`CodeBlock\` copy button shows Copy at rest, Check after click
- [ ] \`Progress\` shows Check on done steps, X on error steps
- [ ] \`Question\` selected option shows Check
- [ ] \`Panel\` empty state shows Sparkles

🤖 Generated with [Claude Code](https://claude.com/claude-code)